### PR TITLE
백준_15678

### DIFF
--- a/1871016_권대현/Boj_15678.java
+++ b/1871016_권대현/Boj_15678.java
@@ -1,0 +1,50 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Comparator;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class Boj_15678 {
+    static class Pair {
+        int index;
+        long value;
+
+        public Pair(int index, long value) {
+            this.index = index;
+            this.value = value;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+        int N = Integer.parseInt(st.nextToken());
+        int D = Integer.parseInt(st.nextToken());
+        PriorityQueue<Pair> pq = new PriorityQueue<>(((o1, o2) -> Long.compare(o2.value, o1.value)));
+
+        StringTokenizer st2 = new StringTokenizer(br.readLine(), " ");
+
+        long max = Long.MIN_VALUE;
+
+        for (int i = 1; i <= N; i++) {
+            // 더이상 더할 수 없는 값(index + D 값이 i보다 작은)을 지워준다.
+            while (!pq.isEmpty() && pq.peek().index + D < i) {
+                pq.poll();
+            }
+            long tmp = 0;
+
+            // 0보다 크고, 더할 수 있는 값 중 가장 큰 값
+            // 0보다 커야 음수가 연속으로 나올 때 더하는 것을 방지할 수 있다.
+            if(!pq.isEmpty() && pq.peek().value>0){
+                tmp = pq.peek().value;
+            }
+            // 다음에 들어올 값과 위의 계산한 값 더해서 추가
+            tmp += Integer.parseInt(st2.nextToken());
+            pq.add(new Pair(i, tmp));
+            // 가장 큰 값을 저장한 max와 비교
+            max = Math.max(tmp, max);
+        }
+        System.out.println(max);
+    }
+}


### PR DESCRIPTION
### 문제 링크
https://www.acmicpc.net/problem/15678

### 어떻게 풀 것인가?
우선순위 큐를 사용해서 푼다.
우선순위 큐에는 인덱스와 값을 쌍으로 저장하고 값을 기준으로 내림차순 정렬한다.
점수를 합산한 값을 우선순위 큐에 넣어준다.
큐의 맨 앞의 인덱스에 D(최대 점프 거리)를 더했을 때 현재 인덱스보다 작으면, 해당 값은 연산이 더 이상 불가능하기 때문에 큐에서 빼준다.
이후 큐의 맨 앞 값이 양수라면 그 값을 기억하고, 이후에 들어오는 값과 더해준다.
더해준 값과 현재 인덱스를 쌍으로 우선순위 큐에 넣어준다.
그리고 최대 값을 구하기 위해 변수를 하나 두어 최대값 비교를 한다.

### 시간복잡도
반복문 안에 반복문이 있는데, 안에 있는 반복문은 최대 큐에 값이 들어간 만큼 수행되기 때문에 O(n)이다.
O(n)

### 풀면서 놓쳤던점
값이 int의 최대 크기를 넘기 때문에 long을 써야하는데, 뒤늦게 알아차렸다.
문제를 잘못 읽어 징검다리를 1부터 밟는줄 알았는데, 아무데서나 밟을 수 있다
