### PR TITLE
백준 9935번 문자열 폭발

### DIFF
--- a/1891059_안민재/Backjoon9935.java
+++ b/1891059_안민재/Backjoon9935.java
@@ -1,0 +1,54 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Stack;
+
+public class Backjoon9935 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String src=br.readLine();
+        String boomStr=br.readLine();
+
+        int length=src.length();
+        int boomStrLength=boomStr.length();
+
+        Stack<Character> stack=new Stack<>();
+        Character end=boomStr.charAt(boomStrLength-1);
+
+        for(int i=0; i<length; i++){
+           stack.push(src.charAt(i));
+
+           boolean isBoomStr=true;
+
+           if(stack.size()>=boomStrLength &&
+                   stack.peek().equals(end)){
+               int index=stack.size()-1;
+
+               for(int j=boomStrLength-1; j>=0; j--){
+                   if(stack.get(index).equals(boomStr.charAt(j)))
+                       index--;
+                   else{
+                       isBoomStr=false;
+                       break;
+                   }
+               }
+
+               if(isBoomStr){
+                   for(int j=0; j<boomStrLength; j++)
+                       stack.pop();
+               }
+
+           }
+        }
+
+        StringBuffer sb=new StringBuffer();
+
+        while(!stack.isEmpty())
+            sb.append(stack.pop());
+
+       sb=sb.reverse();
+        System.out.println(sb.toString().equals("")?"FRULA":sb);
+
+       br.close();
+    }
+}


### PR DESCRIPTION
### 문제 링크

https://www.acmicpc.net/problem/9935

### 어떻게 풀 것인가?

문자열 처리에 관한 문제로 주어진 문자열 내에서 폭발문자열을 탐색하여 제거하기 위해
문자의 순서와 개수를 비교해야 한다는 점에서 스택을 활용하여 접근하였다.
주어진 문자열의 문자들을 스택에 계속 담다가 스택의 사이즈가 폭발문자열의 길이보다 크거나 같을
경우 스택의 위에서부터 폭발문자열의 문자들과 비교하여 같을 시 폭발문자열의 문자들을 스택에서
제거하고 아닐 경우 넘어가서 계속 해서 문자를 담는 식으로 로직을 구성하였다.

연산을 최적화하기 위해 StringBuffer 를 활용하였다.

### 시간복잡도
로직이 수행되는 이중 for문은 O(n^2)의 시간복잡도를 가지고 폭발문자열의 최대 길이가 36이므로
주어진 문제의 시간복잡도를 여유롭게 통과할 수 있게 구성되어 있다.


### 풀면서 놓쳤던점

처음 접근할 시 스택을 어떤 용도로 사용해야할 지에 대한 고민이 부족했던 것 같다.

### 이 문제를 통해 얻어갈 것
비교적 간단해 보이더라도 충분한 검증 과정을 거쳐서 로직을 구성해야 한다는 인사이트를
얻을 수 있는 문제라고 생각된다.
