### PR TITLE
백준 알고리즘 11650 좌표정렬 실버5

### DIFF
--- a/2291048_진민우/BOJ11650.cpp
+++ b/2291048_진민우/BOJ11650.cpp
@@ -1,0 +1,35 @@
+#include <iostream>
+#include <algorithm>
+
+using namespace std;
+
+typedef struct Pos { //구조체 정의
+    int x;
+    int y;
+} Pos;
+
+bool comp(Pos pos1, Pos pos2) {
+    if(pos1.x != pos2.x){ //x좌표 같지 않다면
+        return pos1.x < pos2.x; //오름차순
+    }
+    else{ //x좌표 같다면
+        return pos1.y < pos2.y; //그때는 y좌표 오름차순
+    }
+}
+
+int main(void) {
+    int N;
+    cin >> N;
+
+    Pos pos[N]; //N개의 구조체 배열 선언
+
+    for (int i = 0; i < N; i++) {
+        cin >> pos[i].x >> pos[i].y;
+    }
+
+    sort(&pos[0], &pos[0] + N, comp);
+
+    for(int i = 0; i < N; i++){
+        cout << pos[i].x << " " << pos[i].y << "\n";
+    }
+}


### PR DESCRIPTION
### 문제 링크

https://www.acmicpc.net/problem/11650

### 어떻게 풀 것인가?

+ 처음엔 이중포문을 이용한 선택정렬 사용. -> 시간초과 실패
+ sort함수 사용
+ 구조체에 x좌표 y좌표를 담는다. / 구조체 배열을 만든다.

### 시간복잡도

O(N log N)

### 공간복잡도



### 풀면서 놓쳤던점


### 이 문제를 통해 얻어갈 것

sort함수의 사용법과 원리를 공부합시다.
