### PR TITLE
백준 1194

### DIFF
--- a/1871034_김민성/acmicpc.net/1194.md
+++ b/1871034_김민성/acmicpc.net/1194.md
@@ -1,0 +1,145 @@
+### 문제 링크
+
+https://noj.am/1194
+
+### 어떻게 풀 것인가?
+
+2차원 맵에서 이동 횟수의 최솟값을 찾는 부분에서 BFS를 떠올릴 수 있다. 그런데 이 문제는 키를 가지고 있는 상태에 따라 지나갈 수 있는 길이 다르다. 이 부분을 3차원 배열이라고 생각하면 이해하기 쉽다. 2차원은 맵의 형태이고 그 다음 차원은 키를 가진 상태인 것이다.
+
+그렇다면 키를 가진 조합을 고려해야하는데 어떤 식으로 자료구조를 두면 좋을까? 배열로 하기에는 탐색, 수정하는데 코드가 복잡할 것 같다. 이때 유용한 것이 비트 마스크이다. 비트 마스크는 조합에 쓰이는 원소의 가짓수가 작을 때(N <= 16) 굉장히 유용한 방법이다. 비트 마스크는 [이곳](https://mygumi.tistory.com/361)에 잘 설명되어있다.
+
+소유한 키를 비트마스크로 표현하여 3차원 맵처럼 생각하여 문제를 해결하면 된다.
+
+### 시간복잡도
+
+- 맵의 크기 50 X 50 = 2,500
+- 키의 조합 갯수 2^6 = 64
+
+따라서 O(N^2 \* 2^6)이기 때문에 최악의 경우 160,000으로 시간내에 통과 가능하다.
+
+### 공간복잡도
+
+시간 복잡도와 동일하다.
+
+### 풀면서 놓쳤던점
+
+`discovered` 배열의 크기를 아래와 같이 잘못 선언했었다.
+
+```c++
+bool discovered[MAX_N][MAX_N][(1 << 6) - 1];
+```
+
+최댓값이 (이진수)111111 = 63이기 때문에 64만큼의 공간을 할당하는 것이 맞다.
+
+### 이 문제를 통해 얻어갈 것
+
+비트 마스킹을 활용한 BFS 응용
+
+### 코드
+
+```c++
+#include <cstdio>
+#include <iostream>
+#include <vector>
+#include <queue>
+#include <cstdlib>
+#include <cstring>
+#include <set>
+#include <algorithm>
+#include <climits>
+using namespace std;
+typedef pair<int, int> pii;
+typedef long long ll;
+const int INF = 987654321;
+const int N_INF = -INF;
+const ll LINF = LLONG_MAX;
+
+const int DIR[4][2] = {{0, 1}, {1, 0}, {-1, 0}, {0, -1}};
+const int MAX_N = 51;
+
+int N, M;
+pii starting;
+vector<string> board;
+bool discovered[MAX_N][MAX_N][1 << 6];
+
+inline bool inRange(int y, int x) {
+    return 0 <= y && y < N && 0 <= x && x < M;
+}
+
+inline bool isDoor(char cell) {
+    return 'A' <= cell && cell <= 'F';
+}
+
+inline bool isKey(char cell) {
+    return 'a' <= cell && cell <= 'f';
+}
+
+int bfs() {
+    // {{거리, 찾은 키 비트마스크}, {y, x}}
+    queue<pair<pair<int, int>, pii>> q;
+    q.push({{0, 0}, starting});
+    discovered[starting.first][starting.second][0] = true;
+
+    while (!q.empty()) {
+        int dist = q.front().first.first;
+        int keyBitMask = q.front().first.second;
+        pii here = q.front().second;
+        q.pop();
+
+        if (board[here.first][here.second] == '1') {
+            return dist;
+        }
+        for (int d = 0; d < 4; ++d) {
+            int ny = here.first + DIR[d][0];
+            int nx = here.second + DIR[d][1];
+
+            if (!inRange(ny, nx)
+            || discovered[ny][nx][keyBitMask]
+            || board[ny][nx] == '#') {
+                continue;
+            }
+
+            int cell = board[ny][nx];
+            if (isDoor(cell)) {
+                int cellBitMast = 1 << (cell - 'A');
+                if (!(keyBitMask & cellBitMast)) {
+                    continue;
+                }
+                discovered[ny][nx][keyBitMask] = true;
+                q.push({{1 + dist, keyBitMask}, {ny, nx}});
+            }
+            else if (isKey(cell)) {
+                int cellBitMast = 1 << (cell - 'a');
+                int newKeyBitMask = keyBitMask | cellBitMast;
+                discovered[ny][nx][newKeyBitMask] = true;
+                q.push({{1 + dist, newKeyBitMask}, {ny, nx}});
+            }
+            else {
+                discovered[ny][nx][keyBitMask] = true;
+                q.push({{1 + dist, keyBitMask}, {ny, nx}});
+            }
+        }
+    }
+    return -1;
+}
+
+int main() {
+    ios_base::sync_with_stdio(0); cin.tie(0);
+
+    cin >> N >> M;
+    for (int i = 0; i < N; ++i) {
+        string s;
+        cin >> s;
+        board.push_back(s);
+        for (int j = 0; j < M; ++j) {
+            if (board[i][j] == '0') {
+                starting = {i, j};
+            }
+        }
+    }
+
+    cout << bfs() << endl;
+
+    return 0;
+}
+```


### PR DESCRIPTION
### 문제 링크

https://noj.am/1194

### 어떻게 풀 것인가?

2차원 맵에서 이동 횟수의 최솟값을 찾는 부분에서 BFS를 떠올릴 수 있다. 그런데 이 문제는 키를 가지고 있는 상태에 따라 지나갈 수 있는 길이 다르다. 이 부분을 3차원 배열이라고 생각하면 이해하기 쉽다. 2차원은 맵의 형태이고 그 다음 차원은 키를 가진 상태인 것이다.

그렇다면 키를 가진 조합을 고려해야하는데 어떤 식으로 자료구조를 두면 좋을까? 배열로 하기에는 탐색, 수정하는데 코드가 복잡할 것 같다. 이때 유용한 것이 비트 마스크이다. 비트 마스크는 조합에 쓰이는 원소의 가짓수가 작을 때(N <= 16) 굉장히 유용한 방법이다. 비트 마스크는 [이곳](https://mygumi.tistory.com/361)에 잘 설명되어있다.

소유한 키를 비트마스크로 표현하여 3차원 맵처럼 생각하여 문제를 해결하면 된다.

### 시간복잡도

- 맵의 크기 50 X 50 = 2,500
- 키의 조합 갯수 2^6 = 64

따라서 O(N^2 \* 2^6)이기 때문에 최악의 경우 160,000으로 시간내에 통과 가능하다.

### 공간복잡도

시간 복잡도와 동일하다.

### 풀면서 놓쳤던점

`discovered` 배열의 크기를 아래와 같이 잘못 선언했었다.

```c++
bool discovered[MAX_N][MAX_N][(1 << 6) - 1];
```

최댓값이 (이진수)111111 = 63이기 때문에 64만큼의 공간을 할당하는 것이 맞다.

### 이 문제를 통해 얻어갈 것

비트 마스킹을 활용한 BFS 응용