### PR TITLE
백준 1759

### DIFF
--- a/1871016_권대현/Boj_1759.java
+++ b/1871016_권대현/Boj_1759.java
@@ -1,0 +1,49 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.StringTokenizer;
+
+public class Boj_1759 {
+    static int L;
+    static int C;
+    static String[] mo = {"a", "e", "i", "o", "u"};
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+        L = Integer.parseInt(st.nextToken());
+        C = Integer.parseInt(st.nextToken());
+        ArrayList<String> arr = new ArrayList<>();
+        StringTokenizer st2 = new StringTokenizer(br.readLine(), " ");
+        while (st2.hasMoreTokens()) {
+            arr.add(st2.nextToken());
+        }
+        Collections.sort(arr);
+        BT(arr, 0, "", 0);
+    }
+
+    public static void BT(ArrayList<String> arr, int idx, String pass, int cnt) {
+        if (pass.length() == L) {
+            if (cnt >= 1 && pass.length() - cnt >= 2)
+                System.out.println(pass);
+            return;
+        }
+        StringBuilder passBuilder = new StringBuilder(pass);
+        for (int i = idx; i < C; i++) {
+            passBuilder.append(arr.get(i));
+            int tempCnt = cnt + check(arr.get(i));
+            BT(arr, i + 1, passBuilder.toString(), tempCnt);
+            passBuilder.deleteCharAt(pass.length());
+        }
+    }
+
+    public static int check(String s) {
+        for (int i = 0; i < 5; i++) {
+            if (s.equals(mo[i]))
+                return 1;
+        }
+        return 0;
+    }
+}


### PR DESCRIPTION
### 문제 링크
https://www.acmicpc.net/problem/1759
<!-- 이곳에 해당 문제 url을 입력해주세요. -->

### 어떻게 풀 것인가?
문제의 암호 조건이 최소 한개의 모음, 최소 두개의 자음으로 구성되어있고 암호의 알파벳이 오름차순이라고 나와있다.
따라서 입력받은 문자들을 정렬을 하고 앞에 있는 문자들 부터 찾아나간다.
그리고 암호의 길이가 입력 받은 암호의 길이가 같아졌을 때 암호안에 모음과 자음의 수를 파악해서 올바른 암호면 출력하고 아니면 넘어간다.

<!-- 문제 해결을 위해 어떻게 접근했는 지 알고리즘을 설명해주세요. -->

### 시간복잡도
최대 2^15의 시간 복잡도를 가진다. 
<!-- 시간 복잡도를 어떻게 계산했는지 작성해주세요. -->

### 풀면서 놓쳤던점
문자열을 레퍼런스로 넘겨주기 때문에 재귀를 돌기 전에 문자열에 문자를 추가해주고 끝나고 추가해준 문자열을 지워야 된다.

<!-- 직접 해결하지 못했던 경우 놓친 부분을 작성해주세요. 없다면 지워도 무방합니다. -->

### 이 문제를 통해 얻어갈 것
백트래킹 연습
<!-- 문제의 핵심을 작성해주세요. -->
