### PR TITLE
백준 1010 다리놓기 실버5

### DIFF
--- a/2291048_진민우/BOJ1010.cpp
+++ b/2291048_진민우/BOJ1010.cpp
@@ -1,0 +1,50 @@
+#include <iostream>
+
+using namespace std;
+
+//구조체 정의
+typedef struct bridge {
+    int N;
+    int M;
+    unsigned long long result = 0;
+} Bridge;
+
+//팩토리얼 구하는 함수
+unsigned long long factorial(int n) {
+    int num = n;
+    unsigned long long result = 1;
+    while (num >= 1) {
+        result = result * num;
+        num--;
+    }
+    return result;
+}
+
+//특정한 수를 특정한 횟수 만큼 1씩 빼면서 곱하는 함수.
+unsigned long long half_factorial(int m, int n)
+{
+    int num = m;
+    unsigned long long result = 1;
+    for(int i = 0; i < n; i++){
+        result = result * num;
+        num--;
+    }
+    return result;
+}
+
+
+int main(void) {
+    int T;
+    cin >> T; //테스트 케이스 입력
+
+    Bridge bridge[T]; //테이스 케이스 만큼 구조체 생성
+
+    for (int i = 0; i < T; i++) {
+        cin >> bridge[i].N >> bridge[i].M; //N과 M입력
+        if(bridge[i].N > (bridge[i].M / 2)){ // 조합의 특성 => mCn = mCm-n 이렇게 안하면 오버플로우 남
+            bridge[i].N = bridge[i].M - bridge[i].N;
+        }
+        bridge[i].result = half_factorial(bridge[i].M, bridge[i].N) / factorial(bridge[i].N); //조합을 구함 = mCn
+        cout << bridge[i].result << "\n";
+    }
+}


### PR DESCRIPTION
### 문제 링크

https://www.acmicpc.net/problem/1010

### 어떻게 풀 것인가?

문제를 읽고 바로 떠오른 생각은, **조합**으로 문제를 푸는 것이다.

mCn = m! / (n! * (m - n)!) 의 정의를 사용하면 된다.

동쪽의 M개에서 다리를 연결할 N개를 택하기만 한다면, 자동으로 배치가 되므로,

mCn 을 구하면 된다.

조합을 구하려면  **'팩토리얼'** 을 사용해야한다.

long long 자료형을 선택해도, 16팩토리얼 정도되면 오버플로우가 나기 때문에,

조합의 특성인 mCn = mCm-n을 이용한다.

만약, 29C16는 **29를 절반으로 나눈 14.5를 넘으므로, 29C13으로 표기한다.**

팩토리얼을 구하는 함수도 필요하다.

### 시간복잡도

O(n)

### 공간복잡도

구조체 배열의 개수

### 풀면서 놓쳤던점



### 이 문제를 통해 얻어갈 것

+ 경우의 수를 구하는 '조합'을 구현
+ 팩토리얼 구현
+ 오버플로우 조심하기
