### PR TITLE
백준 9663번 N-Queen

### DIFF
--- a/1891059_안민재/Backjoon9663.java
+++ b/1891059_안민재/Backjoon9663.java
@@ -1,0 +1,41 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class Backjoon9663 {
+    static int N;
+    static int[] trace;
+    static int count=0;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br=new BufferedReader(new InputStreamReader(System.in));
+        N=Integer.parseInt(br.readLine());
+
+        trace=new int[N];
+
+        dfs(0);
+        System.out.println(count);
+    }
+
+    static boolean isValid(int depth){
+        for(int i=0; i<depth; i++){
+            if(trace[i]==trace[depth] || depth-i == Math.abs(trace[depth]-trace[i]))
+                return false;
+        }
+
+        return true;
+    }
+
+    static void dfs(int depth){
+        if(depth==N){
+            count++;
+        } else{
+          for(int i=0; i<N; i++){
+              trace[depth]=i;
+              if(isValid(depth)){
+                  dfs(depth+1);
+              }
+          }
+        }
+    }
+}


### PR DESCRIPTION
### 문제 링크

https://www.acmicpc.net/problem/9663

### 어떻게 풀 것인가?

처음에는 문제에선 주어진 체스판 조건을 2차원 배열로 표현하고 해당 2차원 배열에 현재 놓을 

수 있는 퀸의 위치를 선택, 퀸의 이동 가능 영역을 표시한 후 계속 해서 다음 퀸을 같은 원리로 

배치하고  그에 따른 가능한 경우의 수를 구하는 식의 접근을 생각하였으나, 코드가 지나치게 

복잡해지는 경향이 있어 다른 방향을 고안하였다.

굳이 2차원 배열로 표현할 것이 아니라, 퀸의 위치를 1차원 배열로 배열의 인덱스는 퀸의 row 를, 

배열의 값은 col 을 나타내도록 설정한다. 이렇게 되면 퀸을 배치할때 일단 같은 행에 배치할 수

없다는 조건은 자연스레 필터링할 수 있고, 이제 같은 열에 있으면 안 된다는 조건과 퀸의 대각선

이동 위치에 다른 퀸이 존재해선 안 된다는 조건은 아래와 같이 표현할 수 있다.

현재 `depth` 행에 퀸을 배치한다고 가정하였을때(여기서 `trace[i]` 는 이전 행의, 배치된 퀸의 열 값)

1. 같은 열에 존재하면 안된다는 조건  → `trace[i] == trace[depth]`  
2. 대각선 방향에 존재하면 안된다는 조건 → `depth-i == Math.abs(trace[depth]-trace[i])`
    
    이를테면 (0,0) 위치의 퀸과 (2,2) 위치의 퀸을 생각해보면 위 수식 하나로 문제에 제시된 
    
    4대각선 방향의 경우를 모두 판별할 수 있음을 알 수 있다.
    

위 조건 판별을 이용하여 $dfs$ 를 이용한 백트래킹으로 다음 행에 퀸을 놓을 수 있는 위치가

존재할 경우에만 $dfs$ 를 계속 진행하고 깊이가 $N$ 과 같아지면 모든 퀸을 조건에 따라 놓을 수

있는 경우이므로 카운팅해준다.

### 시간복잡도

이 로직에서 가장 많은 시간이 소요되는 부분은 dfs 고 인접행렬로 표현했을 경우 $O(N^2)$ 의 시간 복잡도를
가진다. 다만, 문제에서 주어진 최대 N의 개수가 15이므로 여유롭게 통과할 수 있다.
실제 4512ms 정도로 통과했다.

### 공간복잡도
1차원 배열을 이용하였고 풀이에 있어 공간복잡도가 크게 영향을 끼치지 않는다.

### 풀면서 놓쳤던점

처음에 무작정 브루트포스로 풀이하려 했으나 문제의 조건을 따져보면 단순화할 수 있는 여지가 충분했다.
문제 접근에 있어 조건 정리 및 단순화를 좀 더 유의해야 겠다는 인사이트를 얻었다.

### 이 문제를 통해 얻어갈 것
백트래킹의 활용, 복잡한 문제 조건을 단순화하려는 접근 태도
