### PR TITLE
백준 1916번 최소비용 구하기

### DIFF
--- a/1891059_안민재/Backjoon1916.java
+++ b/1891059_안민재/Backjoon1916.java
@@ -1,0 +1,71 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Backjoon1916{
+    static int V, E;
+    static int dist[];
+
+    static List<List<Node>> list=new ArrayList<>();
+    static PriorityQueue<Node> pq=new PriorityQueue<>((n1, n2)->Integer.compare(n1.cost, n2.cost));
+    public static void main(String[] args) throws IOException {
+        BufferedReader br=new BufferedReader(new InputStreamReader(System.in));
+        V=Integer.parseInt(br.readLine());
+        E=Integer.parseInt(br.readLine());
+
+        dist=new int[V+1];
+        list.add(new ArrayList<>());
+        for(int i=1; i<=V; i++)
+            list.add(new ArrayList<>());
+
+        StringTokenizer st;
+        for(int i=0; i<E; i++){
+            st=new StringTokenizer(br.readLine());
+            int u=Integer.parseInt(st.nextToken());
+            int v=Integer.parseInt(st.nextToken());
+            int cost=Integer.parseInt(st.nextToken());
+
+            list.get(u).add(new Node(v, cost));
+        }
+
+        st=new StringTokenizer(br.readLine());
+        int start=Integer.parseInt(st.nextToken());
+        int end=Integer.parseInt(st.nextToken());
+
+        dijkstra(start);
+
+        System.out.println(dist[end]);
+        br.close();
+    }
+
+    static void dijkstra(int start){ //O(VlogE)
+        Arrays.fill(dist, Integer.MAX_VALUE);
+        dist[start]=0;
+
+        pq.offer(new Node(start, 0));
+
+        while(!pq.isEmpty()){ //V번 실행(정점의 개수)
+            Node current=pq.poll(); //O(logE)
+
+            if(dist[current.idx]<current.cost)
+                continue;
+
+            for(Node next:list.get(current.idx)){ //O(E)
+                if(dist[next.idx]> current.cost+next.cost){
+                    dist[next.idx]= current.cost+next.cost;
+                    pq.offer(new Node(next.idx, dist[next.idx]));
+                }
+            }
+        }
+    }
+
+    static class Node{
+        int idx, cost;
+
+        public Node(int idx, int cost) {
+            this.idx = idx;
+            this.cost = cost;
+        }
+    }
+}


### PR DESCRIPTION
### 문제 링크

https://www.acmicpc.net/problem/1916

### 어떻게 풀 것인가?

형적인 다익스트라 알고리즘 활용 문제로 우선순위큐를 이용하여 로직을 구성하였다.

도시를 정점에 버스를 간선으로 대입하여 생각하면 쉽게 풀이가 가능하다.

그래프는 인접 리스트로 표현하였다.

`start` 에서 각 정점까지의 최단 경로 비용을 기록하는 `dist` 배열을 설정한다.

예를 들어 `start` 에서 정점 `i` 까지의 최단 경로 비용은 `dist[i]` 이다.

간선의 정보(`Node` )를 저장하는 우선순위큐를 설정한다. 간선의 가중치(비용) 내림차순으로

(적은 비용순)우선순위를 설정한다.

로직의 순서는 아래와 같다.

1. 먼저  `dist` 의 값을 `Integer.MAX_VALUE` 로 설정해준다. `dist` 의 값을 더 작은 값으로 계속 해서
    
    갱신할 것이기 때문에 초기값을 저렇게 설정한다.
    
2. 시작 지점인 `start` 의 `dist` 값을 0으로 설정하고, 우선순위큐에 시작 지점을 넣어준다.

3. 우선순위큐에서 최소 비용에 해당하는 `Node` 를 하나 꺼낸 후 해당 `Node` 의 인접 노드들의
    
    `dist` 값을 갱신해준다. 현재 노드까지의 최단 경로 비용 + 인접 노드로 넘어가는 간선 비용이
    
    현재 인접 노드의 `dist` 값보다 작을 경우만 갱신하고 우선순위큐에 해당 간선을 새로
    
    `Node` 로 만들어 넣어준다. `current` 까지의 최단 경로 비용이 이미 채택된 경우
    
    (`dist[current.idx]<current.cost` )는 넘어가므로 우선순위큐를 이용한 연산은
    
    최대 정점의 개수만큼(`V` ) 이뤄지게 된다.
    
4. 다익스트라 로직을 완료하면 `dist[end]` 에는 `start` 부터 `end` 까지의 최단 경로 비용 값이
    
    설정된다.

### 시간복잡도

문제에서 가장 유의미한 시간 복잡도를 가지는 부분은 다익스트라 로직으로 $O(VlogE)$의
시간 복잡도를 가진다. 최악의 연산의 경우도 무난히 통과할 수 있다.
584ms 의 수행 시간으로 통과하였다.

### 공간복잡도

PriorityQueue 와 List<List> (중첩 리스트)를 사용하였으나 문제 제한 조건을 통과하는데
별 영향이 있는 수준은 아니다.


### 이 문제를 통해 얻어갈 것

다익스트라 알고리즘의 개념, 구현 방식
