### PR TITLE
백준알고리즘 10026번 적록색약

### DIFF
--- a/1891065_오인성/BJ_10026.java
+++ b/1891065_오인성/BJ_10026.java
@@ -1,0 +1,83 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class BJ_10026 {
+
+    static int N;
+    static String S;
+    static char[][] arr;
+    static boolean[][] visits;
+    static int[] dx = {-1, 0, 0, 1};
+    static int[] dy = {0, 1, -1, 0};
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        arr = new char[N + 1][N + 1];
+        visits = new boolean[N + 1][N + 1];
+
+        for (int i = 0; i < N; i++) {
+            S = br.readLine(); // RRRBB
+            for (int j = 0; j < N; j++) {
+                arr[i][j] = S.charAt(j); // R R R B B
+            }
+        }
+
+        // 정상인 경우
+        int cnt = 0;
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < N; j++) {
+                if (!visits[i][j]) {
+                    dfs(i, j);
+                    cnt++;
+                }
+            }
+        }
+        int normal_cnt = cnt;
+        cnt = 0;
+        visits = new boolean[N + 1][N + 1];
+
+        // 비정상인 경우
+        // G를 R로 바꿔주고 돌린다.
+
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < N; j++) {
+                if (arr[i][j] == 'G') {
+                    arr[i][j] = 'R'; // G를 R로 바꿔준다.
+                }
+            }
+        }
+        //
+
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < N; j++) {
+                if (!visits[i][j]) {
+                    dfs(i, j);
+                    cnt++;
+                }
+            }
+        }
+        int abnormal_cnt = cnt;
+        System.out.println(normal_cnt + " " + abnormal_cnt);
+
+    }
+
+    public static void dfs(int x, int y) {
+        visits[x][y] = true;
+        char tmp_char = arr[x][y]; // R
+        for (int i = 0; i < 4; i++) {
+            int new_x = x + dx[i];
+            int new_y = y + dy[i];
+
+            if (new_x < 0 || new_y < 0 || new_x > N || new_y > N) {
+                continue;
+            }
+
+            if (!visits[new_x][new_y] && arr[new_x][new_y] == tmp_char) {
+                dfs(new_x, new_y);
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
### 문제 링크

https://www.acmicpc.net/problem/10026
https://superohinsung.tistory.com/102

### 어떻게 풀 것인가?

2023년 2월 기준 난 아직도 BFS 와 DFS에 많이 약하다고 생각한다. 그래서 문제를 맨 처음에 접근을 하였을 때 굉장히 어렵게 느껴졌다.

다만 이에 조금 블로그와 문제풀이를 참고하여 문제를 풀었다.

이 문제에서 요구하는 것은 DFS이다. DFS를 통하여 인접행렬을 차례로 순회하여 방문경로를 체크하고 이에 따른 구역의 갯수를 찾는다.

또한 적록색약인 사람과 적록색약이 아닌 사람과의 구분을 통해서 답을 얻는다.(이 부분은 굉장히 쉽다)

### 시간복잡도

주어진 시간제한은 1초였다. 다만, 문제에서 최대로 요구되어지는 N은 100개미만임으로 크게 고려를 해도 되지않는다.

그래도 이차원 배열에 따른 DFS함수를 통한 방문경로를 계산해야함으로 시간복잡도는 O(N^2) 이다.

### 공간복잡도

주어진 N에 따른 arr 2차원 배열에 공간복잡도만 계산하면 충분할 것이다. 따라서 O(N^2) 이다.

### 풀면서 놓쳤던점

DFS와 BFS 그리고 그래프에 대한 개념을 보완해야할 것 같다.

### 이 문제를 통해 얻어갈 것

DFS 문제에 대한 접근을 많이 해야할 것 같다. 조금씩 패턴이 보이고, DFS문제에 대한 정석적인 방법을 공부할 수 있었다.
