### PR TITLE
백준 10866 덱 실버4

### DIFF
--- a/2291048_진민우/BOJ10866.c
+++ b/2291048_진민우/BOJ10866.c
@@ -1,0 +1,137 @@
+#include <stdio.h>
+#include <string.h>
+#define MAX_SIZE 10000
+
+typedef int element;
+typedef struct {
+    int front;
+    int rear;
+    int data[MAX_SIZE];
+} DequeType;
+
+void init_deque(DequeType *dq) {
+    dq->front = 0;
+    dq->rear = 0;
+    for(int i = 0; i < MAX_SIZE; i++) {
+        dq->data[i] = 0;
+    }
+}
+
+void push_front(DequeType *dq, element item) {
+    dq->data[dq->front] = item;
+    dq->front = (dq->front - 1 + MAX_SIZE) %  MAX_SIZE;
+}
+
+void push_back(DequeType *dq, element item) {
+    dq->rear = (dq->rear + 1) % MAX_SIZE;
+    dq->data[dq->rear] = item;
+}
+
+element pop_front(DequeType *dq) {
+    int value;
+    if(dq->front == dq->rear) {
+        return -1;
+    }
+    else {
+        dq->front = (dq->front + 1) % MAX_SIZE;
+        value = dq->data[dq->front];
+        dq->data[dq->front] = 0;
+        return value;
+    }
+}
+
+element pop_back(DequeType *dq) {
+    int value;
+    if(dq->front == dq->rear) {
+        return -1;
+    }
+    else {
+        value = dq->data[dq->rear];
+        dq->data[dq->rear] = 0;
+        dq->rear = (dq->rear - 1 + MAX_SIZE) % MAX_SIZE;
+        return value;
+    }
+}
+
+int size(DequeType *dq) {
+    int size = 0;
+    for(int i = 0; i < MAX_SIZE; i++) {
+        if(dq->data[i] != 0) {
+            size++;
+        }
+    }
+    return size;
+}
+
+void empty(DequeType *dq) {
+    if(dq->front == dq->rear) {
+        printf("1\n");
+    }
+    else {
+        printf("0\n");
+    }
+}
+
+void front(DequeType *dq) {
+    int value;
+    if(dq->front == dq->rear) {
+        printf("-1\n");
+    }
+    else {
+        value = dq->data[(dq->front + 1) % MAX_SIZE];
+        printf("%d\n", value);
+    }
+}
+
+void back(DequeType *dq) {
+    int value;
+    if(dq->front == dq->rear) {
+        printf("-1\n");
+    }
+    else {
+        value = dq->data[dq->rear];
+        printf("%d\n", value);
+    }
+}
+
+int main(void){
+    int value;
+    char command[11];
+    int N;
+    scanf("%d", &N);
+
+    DequeType dq;
+    init_deque(&dq);
+
+
+    for(int i = 0; i < N; i++) {
+        scanf("%s", command);
+        if(strcmp(command, "push_front") == 0) {
+            scanf("%d", &value);
+            push_front(&dq, value);
+        }
+        else if(strcmp(command, "push_back") == 0) {
+            scanf("%d", &value);
+            push_back(&dq, value);
+        }
+        else if(strcmp(command, "pop_front") == 0) {
+            printf("%d\n", pop_front(&dq));
+        }
+        else if(strcmp(command, "pop_back") == 0) {
+            printf("%d\n", pop_back(&dq));
+        }
+        else if(strcmp(command, "size") == 0) {
+            printf("%d\n", size(&dq));
+        }
+        else if(strcmp(command, "empty") == 0) {
+            empty(&dq);
+        }
+        else if(strcmp(command, "front") == 0) {
+            front(&dq);
+        }
+        else if(strcmp(command, "back") == 0) {
+            back(&dq);
+        }
+    }
+    return 0;
+}


### PR DESCRIPTION
### 문제 링크

https://www.acmicpc.net/problem/10866

### 어떻게 풀 것인가?

덱을 구현하면 된다.
본인은 원형 덱을 구현했음.

+ mod연산 활용.
+ 데이터 삭제시 삭제했다는 표시로 0을 삽입함.
+ 덱 크기를 구할 때, 0이 아닌 데이터의 개수만 구하면 됨.

### 시간복잡도

O(n)

### 공간복잡도

data[10000]이다.
공간복잡도는 덱의 크기이다.

### 풀면서 놓쳤던점



### 이 문제를 통해 얻어갈 것

mod연산 사용 -> '원형' 덱 이기 때문에

덱의 사이즈를 구하는 방법 -> 0이 아닌 데이터의 개수를 센다.

덱의 사이즈를 구하려고 rear - front를 하려했는데, '원형덱'이라 어려움이 있었다.
